### PR TITLE
[BB-548] Add new flag for metabase plan

### DIFF
--- a/.github/workflows/capabilities_and_config.yaml
+++ b/.github/workflows/capabilities_and_config.yaml
@@ -31,6 +31,7 @@ jobs:
         env:
           BATON_METABASE_API_KEY: apiKey
           BATON_METABASE_BASE_URL: https://metabase.someurl.com
+          BATON_METABASE_PAID_MODE: false
         run: ./connector capabilities > baton_capabilities.json
 
       - name: Commit changes

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Available Commands:
   help               Help about any command
 
 Flags:
+      --metabase-with-paid-plan bool      Whether the Metabase instance is running a paid plan. Enables premium entitlements ($METABASE_WITH_PAID_PLAN)   
       --metabase-base-url string     The base URL of the Metabase instance. e.g., https://metabase.customer.com ($METABASE_BASE_URL)
       --metabase-api-key string      API key generated in Metabase for the connector ($METABASE_API_KEY)
       --client-id string             The client ID used to authenticate with ConductorOne ($BATON_CLIENT_ID)

--- a/docs/docs-info.md
+++ b/docs/docs-info.md
@@ -39,6 +39,10 @@ For the previous case of docker commands, the base URL would be:
 
    Requires a base URL and an API Key. Args: --metabase-base-url, --metabase-api-key
 
+   There is also the --metabase-with-paid-plan flag, to determine whether the connector is using the free open source version or a paid version of Metabase, 
+   which will add the group_manager permission that makes sense in paid versions because it is not allowed to use it for free.
+   By default, the flag is false.
+
    The required URL was defined in the connector requirements instructions
    To obtain the API key follow the next steps:  
    1. In your Metabase address where the open source version was launched, click on the gear icon in the upper right section and click on admin settings:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -36,12 +36,13 @@ const (
 )
 
 type MetabaseClient struct {
-	client  *uhttp.BaseHttpClient
-	baseURL *url.URL
-	apiKey  string
+	client     *uhttp.BaseHttpClient
+	baseURL    *url.URL
+	apiKey     string
+	isPaidPlan bool
 }
 
-func New(ctx context.Context, rawBaseURL string, apiKey string) (*MetabaseClient, error) {
+func New(ctx context.Context, rawBaseURL string, apiKey string, isPaidPlan bool) (*MetabaseClient, error) {
 	client, err := uhttp.NewClient(ctx)
 	if err != nil {
 		return nil, err
@@ -58,9 +59,10 @@ func New(ctx context.Context, rawBaseURL string, apiKey string) (*MetabaseClient
 	}
 
 	return &MetabaseClient{
-		client:  httpClient,
-		baseURL: baseURL,
-		apiKey:  apiKey,
+		client:     httpClient,
+		baseURL:    baseURL,
+		apiKey:     apiKey,
+		isPaidPlan: isPaidPlan,
 	}, nil
 }
 
@@ -180,4 +182,8 @@ func (c *MetabaseClient) GetVersion(ctx context.Context) (*VersionInfo, *v2.Rate
 	}
 
 	return &utilInfo, rateLimitDesc, nil
+}
+
+func (c *MetabaseClient) IsPaidPlan() bool {
+	return c.isPaidPlan
 }

--- a/pkg/client/client_interface.go
+++ b/pkg/client/client_interface.go
@@ -11,4 +11,5 @@ type ClientService interface {
 	ListGroups(ctx context.Context) ([]*Group, *v2.RateLimitDescription, error)
 	ListMemberships(ctx context.Context) (map[string][]*Membership, *v2.RateLimitDescription, error)
 	GetVersion(ctx context.Context) (*VersionInfo, *v2.RateLimitDescription, error)
+	IsPaidPlan() bool
 }

--- a/pkg/client/client_mock.go
+++ b/pkg/client/client_mock.go
@@ -11,6 +11,7 @@ type MockService struct {
 	ListGroupsFunc      func(ctx context.Context) ([]*Group, *v2.RateLimitDescription, error)
 	ListMembershipsFunc func(ctx context.Context) (map[string][]*Membership, *v2.RateLimitDescription, error)
 	GetVersionFunc      func(ctx context.Context) (*VersionInfo, *v2.RateLimitDescription, error)
+	IsPaidPlanFunc      func() bool
 }
 
 func (m *MockService) ListUsers(ctx context.Context, options PageOptions) ([]*User, string, *v2.RateLimitDescription, error) {
@@ -27,4 +28,11 @@ func (m *MockService) ListMemberships(ctx context.Context) (map[string][]*Member
 
 func (m *MockService) GetVersion(ctx context.Context) (*VersionInfo, *v2.RateLimitDescription, error) {
 	return m.GetVersionFunc(ctx)
+}
+
+func (m *MockService) IsPaidPlan() bool {
+	if m.IsPaidPlanFunc != nil {
+		return m.IsPaidPlanFunc()
+	}
+	return false
 }

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -4,8 +4,9 @@ package config
 import "reflect"
 
 type Metabase struct {
-	MetabaseBaseUrl string `mapstructure:"metabase-base-url"`
-	MetabaseApiKey  string `mapstructure:"metabase-api-key"`
+	MetabaseBaseUrl      string `mapstructure:"metabase-base-url"`
+	MetabaseApiKey       string `mapstructure:"metabase-api-key"`
+	MetabaseWithPaidPlan bool   `mapstructure:"metabase-with-paid-plan"`
 }
 
 func (c *Metabase) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,10 +20,18 @@ var (
 		field.WithDisplayName("API Key"),
 	)
 
+	MetabaseWithPaidPlan = field.BoolField(
+		"metabase-with-paid-plan",
+		field.WithDescription("Set to true if using Metabase paid plan, false for Open Source / self-hosted (free)"),
+		field.WithDisplayName("Metabase with paid plan"),
+		field.WithDefaultValue(false),
+	)
+
 	// ConfigurationFields defines the external configuration required for the connector to run.
 	ConfigurationFields = []field.SchemaField{
 		MetabaseBaseUrl,
 		MetabaseApiKey,
+		MetabaseWithPaidPlan,
 	}
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -49,7 +49,7 @@ func (d *Connector) Validate(_ context.Context) (annotations.Annotations, error)
 func New(ctx context.Context, config *cfg.Metabase) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
 
-	metabaseClient, err := client.New(ctx, config.MetabaseBaseUrl, config.MetabaseApiKey)
+	metabaseClient, err := client.New(ctx, config.MetabaseBaseUrl, config.MetabaseApiKey, config.MetabaseWithPaidPlan)
 	if err != nil {
 		l.Error("error creating metabase client", zap.Error(err))
 		return nil, err

--- a/pkg/connector/groups_test.go
+++ b/pkg/connector/groups_test.go
@@ -82,8 +82,9 @@ func TestGroupsEntitlements(t *testing.T) {
 		DisplayName: "All Users",
 	}
 
-	t.Run("should return member and manager entitlements", func(t *testing.T) {
-		groupBuilder, _ := newTestGroupBuilder()
+	t.Run("should return both member and manager entitlements for paid plan", func(t *testing.T) {
+		groupBuilder, mockClient := newTestGroupBuilder()
+		mockClient.IsPaidPlanFunc = func() bool { return true }
 
 		entitlements, _, _, err := groupBuilder.Entitlements(ctx, groupResource, &pagination.Token{})
 		require.NoError(t, err)
@@ -96,5 +97,16 @@ func TestGroupsEntitlements(t *testing.T) {
 
 		require.Contains(t, ids, "group:1:member")
 		require.Contains(t, ids, "group:1:manager")
+	})
+
+	t.Run("should return only member entitlement for free plan", func(t *testing.T) {
+		groupBuilder, mockClient := newTestGroupBuilder()
+		mockClient.IsPaidPlanFunc = func() bool { return false }
+
+		entitlements, _, _, err := groupBuilder.Entitlements(ctx, groupResource, &pagination.Token{})
+		require.NoError(t, err)
+		require.Len(t, entitlements, 1)
+
+		require.Equal(t, "group:1:member", entitlements[0].Id)
 	})
 }


### PR DESCRIPTION
#### Description

- [ ] Bug fix
- [x] New feature




#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration support to specify Metabase plan type (paid or open-source)
  * Role availability now depends on plan type: paid plans offer Manager entitlements alongside Member entitlements, while free/open-source plans provide only Member entitlements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->