### PR TITLE
docs: apply C1 rebrand to connector.mdx

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up Metabase connector"
 og:title: "Set up Metabase connector"
-description: "ConductorOne provides identity governance and just-in-time provisioning for Metabase. Integrate your Metabase instance with ConductorOne to run user access reviews (UARs) and enable just-in-time access requests."
-og:description: "ConductorOne provides identity governance and just-in-time provisioning for Metabase. Integrate your Metabase instance with ConductorOne to run user access reviews (UARs) and enable just-in-time access requests."
+description: "C1 provides identity governance and just-in-time provisioning for Metabase. Integrate your Metabase instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
+og:description: "C1 provides identity governance and just-in-time provisioning for Metabase. Integrate your Metabase instance with C1 to run user access reviews (UARs) and enable just-in-time access requests."
 sidebarTitle: "Metabase"
 ---
 
@@ -30,18 +30,18 @@ See the docs below for details on the capabilities of each version and instructi
 
 | Resource | Sync | Provision |
 | :--- | :--- | :--- |
-| Account | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |
-| Group | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |
+| Account | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Group | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 
 The Metabase connector supports [automatic account provisioning](/product/admin/account-provisioning). 
 
-When a new account is created by ConductorOne, the account's password will be sent to a [vault](/product/admin/vaults). 
+When a new account is created by C1, the account's password will be sent to a [vault](/product/admin/vaults). 
 
 The Metabase connector cannot fully deprovision accounts, but it can enable and disable existing accounts.
 
 #### Connector actions
 
-Connector actions are custom capabilities that extend ConductorOne automations with app-specific operations. You can use connector actions in the [Perform connector action](/product/admin/automations-steps-reference#perform-connector-action) automation step.
+Connector actions are custom capabilities that extend C1 automations with app-specific operations. You can use connector actions in the [Perform connector action](/product/admin/automations-steps-reference#perform-connector-action) automation step.
 
 | Action name | Additional fields | Description |
 |-------------|-------------------|-------------|
@@ -52,19 +52,19 @@ Connector actions are custom capabilities that extend ConductorOne automations w
 
 | Resource | Sync | Provision |
 | :--- | :--- | :--- |
-| Account | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |
-| Database | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |  |
-| Group | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |
+| Account | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Database | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
+| Group | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 
 The Metabase v0.49 connector supports [automatic account provisioning](/product/admin/account-provisioning). 
 
-When a new account is created by ConductorOne, the account's password will be sent to a [vault](/product/admin/vaults). 
+When a new account is created by C1, the account's password will be sent to a [vault](/product/admin/vaults). 
 
 The Metabase v0.49 connector cannot fully deprovision accounts, but it can enable and disable existing accounts.
 
 #### Connector actions
 
-Connector actions are custom capabilities that extend ConductorOne automations with app-specific operations. You can use connector actions in the [Perform connector action](/product/admin/automations-steps-reference#perform-connector-action) automation step.
+Connector actions are custom capabilities that extend C1 automations with app-specific operations. You can use connector actions in the [Perform connector action](/product/admin/automations-steps-reference#perform-connector-action) automation step.
 
 | Action name | Additional fields | Description |
 |-------------|-------------------|-------------|
@@ -75,19 +75,19 @@ Connector actions are custom capabilities that extend ConductorOne automations w
 
 | Resource | Sync | Provision |
 | :--- | :--- | :--- |
-| Account | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |
-| Database | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |  |
-| Group | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> | <Icon icon="square-check" iconType="solid"  color="#65DE23"/> |
+| Account | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
+| Database | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |
+| Group | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 
 The Metabase v0.56 connector supports [automatic account provisioning](/product/admin/account-provisioning). 
 
-When a new account is created by ConductorOne, the account's password will be sent to a [vault](/product/admin/vaults). 
+When a new account is created by C1, the account's password will be sent to a [vault](/product/admin/vaults). 
 
 The Metabase v0.56 connector cannot fully deprovision accounts, but it can enable and disable existing accounts.
 
 #### Connector actions
 
-Connector actions are custom capabilities that extend ConductorOne automations with app-specific operations. You can use connector actions in the [Perform connector action](/product/admin/automations-steps-reference#perform-connector-action) automation step.
+Connector actions are custom capabilities that extend C1 automations with app-specific operations. You can use connector actions in the [Perform connector action](/product/admin/automations-steps-reference#perform-connector-action) automation step.
 
 | Action name | Additional fields | Description |
 |-------------|-------------------|-------------|
@@ -118,17 +118,17 @@ This connector requires the following scopes:
 <Warning>
 To complete this task, you'll need:
 
-- The **Connector Administrator** or **Super Administrator** role in ConductorOne
+- The **Connector Administrator** or **Super Administrator** role in C1
 - Access to the set of Metabase configuration information gathered by following the instructions above
 </Warning>
 
 <Tabs>
 <Tab title="Cloud-hosted">
-**Follow these instructions to use a built-in, no-code connector hosted by ConductorOne.**
+**Follow these instructions to use a built-in, no-code connector hosted by C1.**
 
 <Steps>
 <Step>
-In ConductorOne, navigate to **Integrations** > **Connectors** and click **Add connector**.
+In C1, navigate to **Integrations** > **Connectors** and click **Add connector**.
 </Step>
 <Step>
 As relevant, search for **Metabase**, **Metabase v0.49** or **Metabase v0.56** and click **Add**.
@@ -136,16 +136,16 @@ As relevant, search for **Metabase**, **Metabase v0.49** or **Metabase v0.56** a
 <Step>
 Choose how to set up the new Metabase connector:
 
-   - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with ConductorOne)
+   - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
 
    - Add the connector to a managed app (select from the list of existing managed apps)
 
    - Create a new managed app
 </Step>
 <Step>
-Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of ConductorOne users. Setting multiple owners is allowed.
+Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed.
 
-   If you choose someone else, ConductorOne will notify the new connector owner by email that their help is needed to complete the setup process.
+   If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
 </Step>
 <Step>
 Click **Next**.
@@ -164,23 +164,23 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Metabase connector is now pulling access data into ConductorOne.
+**That's it!** Your Metabase connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
 **Follow these instructions to use the Metabase connector, hosted and run in your own environment.**
 
-When running in service mode on Kubernetes, a self-hosted connector maintains an ongoing connection with ConductorOne, automatically syncing and uploading data at regular intervals. This data is immediately available in the ConductorOne UI for access reviews and access requests.
+When running in service mode on Kubernetes, a self-hosted connector maintains an ongoing connection with C1, automatically syncing and uploading data at regular intervals. This data is immediately available in the C1 UI for access reviews and access requests.
 
 ### Resources
 
-* [GitHub repository](https://github.com/ConductorOne/baton-metabase): Access the source code, report issues, or contribute to the project.
+* [GitHub repository](https://github.com/conductorone/baton-metabase): Access the source code, report issues, or contribute to the project.
 
 ### Step 1: Set up a new Metabase connector
 
 <Steps>
 <Step>
-In ConductorOne, navigate to **Integrations** > **Connectors** > **Add connector**.
+In C1, navigate to **Integrations** > **Connectors** > **Add connector**.
 </Step>
 <Step>
 Search for **Baton** and click **Add**.
@@ -188,16 +188,16 @@ Search for **Baton** and click **Add**.
 <Step>
 Choose how to set up the new Metabase connector:
 
-   - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with ConductorOne)
+   - Add the connector to a currently unmanaged app (select from the list of apps that were discovered in your identity, SSO, or federation provider that aren't yet managed with C1)
 
    - Add the connector to a managed app (select from the list of existing managed apps)
 
    - Create a new managed app
 </Step>
 <Step>
-Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of ConductorOne users. Setting multiple owners is allowed.
+Set the owner for this connector. You can manage the connector yourself, or choose someone else from the list of C1 users. Setting multiple owners is allowed.
 
-   If you choose someone else, ConductorOne will notify the new connector owner by email that their help is needed to complete the setup process.
+   If you choose someone else, C1 will notify the new connector owner by email that their help is needed to complete the setup process.
 </Step>
 <Step>
 Click **Next**.
@@ -228,15 +228,15 @@ metadata:
   name: baton-metabase-secrets
 type: Opaque
 stringData:
-  # ConductorOne credentials
-  BATON_CLIENT_ID: <ConductorOne client ID>
-  BATON_CLIENT_SECRET: <ConductorOne client secret>
+  # C1 credentials
+  BATON_CLIENT_ID: <C1 client ID>
+  BATON_CLIENT_SECRET: <C1 client secret>
 
   # Metabase config
   BATON_METABASE_API_KEY: <Metabase API Key>
   BATON_METABASE_BASE_URL: <Metabase Base URL>
 
-  # Optional: include if you want ConductorOne to provision access using this connector
+  # Optional: include if you want C1 to provision access using this connector
   BATON_PROVISIONING: true
 ```
 
@@ -287,15 +287,15 @@ metadata:
   name: baton-metabase-v049-secrets
 type: Opaque
 stringData:
-  # ConductorOne credentials
-  BATON_CLIENT_ID: <ConductorOne client ID>
-  BATON_CLIENT_SECRET: <ConductorOne client secret>
+  # C1 credentials
+  BATON_CLIENT_ID: <C1 client ID>
+  BATON_CLIENT_SECRET: <C1 client secret>
 
   # Metabase config
   BATON_METABASE_API_KEY: <Metabase API Key>
   BATON_METABASE_BASE_URL: <Metabase Base URL>
 
-  # Optional: include if you want ConductorOne to provision access using this connector
+  # Optional: include if you want C1 to provision access using this connector
   BATON_PROVISIONING: true
 ```
 
@@ -346,15 +346,15 @@ metadata:
   name: baton-metabase-v056-secrets
 type: Opaque
 stringData:
-  # ConductorOne credentials
-  BATON_CLIENT_ID: <ConductorOne client ID>
-  BATON_CLIENT_SECRET: <ConductorOne client secret>
+  # C1 credentials
+  BATON_CLIENT_ID: <C1 client ID>
+  BATON_CLIENT_SECRET: <C1 client secret>
 
   # Metabase config
   BATON_METABASE_API_KEY: <Metabase API Key>
   BATON_METABASE_BASE_URL: <Metabase Base URL>
 
-  # Optional: include if you want ConductorOne to provision access using this connector
+  # Optional: include if you want C1 to provision access using this connector
   BATON_PROVISIONING: true
 ```
 
@@ -397,14 +397,14 @@ spec:
 
 <Steps>
 <Step>
-Create a namespace in which to run ConductorOne connectors (if desired), then apply the secret config and deployment config files.
+Create a namespace in which to run C1 connectors (if desired), then apply the secret config and deployment config files.
 </Step>
 <Step>
-Check that the connector data uploaded correctly. In ConductorOne, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the metabase connector to. metabase data should be found on the **Entitlements** and **Accounts** tabs.
+Check that the connector data uploaded correctly. In C1, click **Apps**. On the **Managed apps** tab, locate and click the name of the application you added the metabase connector to. metabase data should be found on the **Entitlements** and **Accounts** tabs.
 </Step>
 </Steps>
 
-**That's it!** Your Metabase connector is now pulling access data into ConductorOne.
+**That's it!** Your Metabase connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Updates `docs/connector.mdx` with the C1 rebrand:

- Renames **ConductorOne** → **C1** in prose, comments, and placeholder text
- Updates brand color `#65DE23` → `#c937ae`
- Lowercases GitHub org name in the repository resource link

URLs that are case-sensitive or functional (distro site, tenant URLs, email addresses, file paths) are unchanged.