### PR TITLE
docs: update Docker image registry from GHCR to ECR Public

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -265,7 +265,7 @@ spec:
     spec:
       containers:
       - name: baton-metabase
-        image: ghcr.io/conductorone/baton-metabase:latest
+        image: public.ecr.aws/conductorone/baton-metabase:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -324,7 +324,7 @@ spec:
     spec:
       containers:
       - name: baton-metabase-v049
-        image: ghcr.io/conductorone/baton-metabase-v049:latest
+        image: public.ecr.aws/conductorone/baton-metabase-v049:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -383,7 +383,7 @@ spec:
     spec:
       containers:
       - name: baton-metabase-v056
-        image: ghcr.io/conductorone/baton-metabase-v056:latest
+        image: public.ecr.aws/conductorone/baton-metabase-v056:latest
         imagePullPolicy: IfNotPresent
         env:
         - name: BATON_HOST_ID
@@ -407,5 +407,3 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 **That's it!** Your Metabase connector is now pulling access data into C1.
 </Tab>
 </Tabs>
-
-


### PR DESCRIPTION
## Summary

Connector images are now published exclusively to ECR Public (`public.ecr.aws/conductorone/`). This PR updates `docs/connector.mdx` accordingly.

**Changes made:**
- Updates Docker image reference from `ghcr.io/conductorone/` to `public.ecr.aws/conductorone/`
- Adds `### Resources` section (download center + GitHub repo links) if missing from the self-hosted setup instructions

_This PR was generated automatically._