### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -164,7 +164,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Metabase connector is now pulling access data into C1.
+**Done.** Your Metabase connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -404,6 +404,6 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Metabase connector is now pulling access data into C1.
+**Done.** Your Metabase connector is now pulling access data into C1.
 </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.